### PR TITLE
chore 0409: add license; export types

### DIFF
--- a/Code/Avernakis Nodejs/Test-Nodejs/src/Ave/Io/index.ts
+++ b/Code/Avernakis Nodejs/Test-Nodejs/src/Ave/Io/index.ts
@@ -1,0 +1,1 @@
+export * from "./IoCommon";

--- a/Code/Avernakis Nodejs/Test-Nodejs/src/Ave/Ui/index.ts
+++ b/Code/Avernakis Nodejs/Test-Nodejs/src/Ave/Ui/index.ts
@@ -1,1 +1,2 @@
 export * from "./UiControl";
+export * from "./UiPainter";

--- a/Code/Avernakis Nodejs/Test-Nodejs/src/Ave/index.ts
+++ b/Code/Avernakis Nodejs/Test-Nodejs/src/Ave/index.ts
@@ -1,3 +1,4 @@
 export * from "./Ave";
 export * from "./AveLib";
 export * from "./Ui";
+export * from "./Io";

--- a/Code/External/node-addon-api/LICENSE.md
+++ b/Code/External/node-addon-api/LICENSE.md
@@ -1,0 +1,11 @@
+# The MIT License (MIT)
+
+## Copyright (c) 2017 Node.js API collaborators
+
+_Node.js API collaborators listed at <https://github.com/nodejs/node-addon-api#collaborators>_
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Code/External/node-gyp/12.16.2/LICENSE.md
+++ b/Code/External/node-gyp/12.16.2/LICENSE.md
@@ -1,0 +1,24 @@
+(The MIT License)
+
+Copyright (c) 2012 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
import them from "ave-ui", instead of "ave-ui/xxx/xxx/xxx"

![image](https://user-images.githubusercontent.com/87927336/162561098-c08f9f4d-6e09-49ba-b43a-4f2276e3fd2d.png)

![image](https://user-images.githubusercontent.com/87927336/162561121-d20f259c-568b-4dcc-8555-8b983fbb4bb7.png)
